### PR TITLE
Add missing $response_content variable

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,3 +4,5 @@ requires 'HTTP::Request::Common';
 requires 'AWS::Signature4';
 requires 'JSON';
 requires 'XML::Simple';
+requires 'LWP::UserAgent';
+requires 'URI::Escape';

--- a/cpanfile
+++ b/cpanfile
@@ -6,3 +6,7 @@ requires 'JSON';
 requires 'XML::Simple';
 requires 'LWP::UserAgent';
 requires 'URI::Escape';
+
+on 'test' => sub {
+    requires 'Test::More', '0.98';
+};

--- a/lib/Amazon/SNS/V4.pm
+++ b/lib/Amazon/SNS/V4.pm
@@ -143,10 +143,11 @@ sub dispatch
 				'ForceArray' => [ qw/ Topics member / ],
 		);
 	} else {
+		my $response_content = $response->content;
 		$self->error_response( $response_content );
 		$self->error(
-			($response->content =~ /^<.+>/)
-				? eval { XMLin($response->content)->{'Error'}{'Message'} || $response->status_line }
+			($response_content =~ /^<.+>/)
+				? eval { XMLin($response_content)->{'Error'}{'Message'} || $response->status_line }
 				: $response->status_line
 		);
 	}

--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -1,0 +1,8 @@
+use strict;
+use Test::More 0.98;
+
+use_ok $_ for qw(
+    Amazon::SNS::V4
+);
+
+done_testing;


### PR DESCRIPTION
Amazon::SNS::V4 version 1.9 seems doesn't work due to the following error, and I fixed it and added a compile test.
```
Global symbol "$response_content" requires explicit package name (did you forget to declare "my $response_content"?) at /cpan/lib/perl5/Amazon/SNS/V4.pm line 146.
```